### PR TITLE
fix: 隔离 GitHub Pages 部署写入权限

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,22 +6,22 @@ on:
       - masrer
 
 permissions:
-  contents: write
-  deployments: write
+  contents: read
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    name: 构建和部署
+    name: 构建
 
     steps:
       - name: 检出代码
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 设置Node.js环境
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 18
           cache: npm
@@ -49,6 +49,29 @@ jobs:
 
       - name: 复制首页文件用于SPA路由支持
         run: cp dist/index.html dist/404.html
+
+      - name: 上传构建产物
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: github-pages-dist
+          path: dist
+          if-no-files-found: error
+
+  deploy:
+    runs-on: ubuntu-latest
+    name: 部署
+    needs: build
+    permissions:
+      actions: read
+      contents: write
+      deployments: write
+
+    steps:
+      - name: 下载构建产物
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: github-pages-dist
+          path: dist
 
       - name: 部署到GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
### Motivation
- 修复工作流将写权限授予整个构建-部署流程的问题，避免在 checkout、依赖安装或构建阶段暴露可写的 `GITHUB_TOKEN` 从而被滥用。

### Description
- 将工作流顶层 `permissions` 中的 `contents: write` 降级为 `contents: read`，防止构建阶段持有写权限。
- 将原单一 `build-and-deploy` 作业拆分为独立的 `build` 和 `deploy` 两个 job，并通过 artifact 在两者之间传递 `dist` 输出。
- 在 `build` 作业的 `actions/checkout` 中禁用持久化凭据 (`persist-credentials: false`) 并把 `checkout`、`setup-node`、`upload-artifact`、`download-artifact` 等关键第三方 Actions 固定到不可变的提交 SHA。
- 仅在 `deploy` 作业中授予必要的写权限（`contents: write` 与 `deployments: write`），并设置 `deploy` 依赖于 `build` 完成后运行。

### Testing
- 运行 `git diff --check` 并通过，变更格式与语法无冲突。
- 使用 Ruby 脚本解析 `.github/workflows/deploy.yml` 并验证存在 `build` 与 `deploy` 两个作业，检查通过。
- 尝试运行 `npm ci`、`npm run lint` 与 `npm run build` 时受限于环境网络策略导致依赖安装失败（出现缺失 `is-glob` / `vite` 等包），因此 lint 与 build 在本环境下未能完成，但这为环境依赖问题而非工作流改动引起。
- 已提交变更并验证 `git status` 为干净工作树。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6997da5b348326a84b6fbe60a27033)